### PR TITLE
修复school第二行为空出现的错误显示问题

### DIFF
--- a/swjtuThesis.cls
+++ b/swjtuThesis.cls
@@ -298,7 +298,8 @@
 					{\cover@eTutor}   	& \fillinblank{12em}{\@eTutor}
 						\\
 					{\cover@eSchool}   	& \fillinblank{12em}{\@eSchoolFirst}
-					\ifx\@eSchoolSecond\empty\else \\ {}& \fillinblank{12em}{\@eSchoolSecond} \fi
+					\\
+					\ifx\@eSchoolSecond\empty\else {}& \fillinblank{12em}{\@eSchoolSecond} \fi
 				\end{tabular}
 			}
 			\vfill


### PR DESCRIPTION
如果eSchoolSecond为空，会显示错误，只有一根错位横线。将换行符提前就可以避免。