### PR TITLE
修改了参考文献中英文会议论文volume和num的显示问题

### DIFF
--- a/ref/swjtuBST.bst
+++ b/ref/swjtuBST.bst
@@ -812,7 +812,7 @@ FUNCTION {format.vol.num.pages}
 { volume field.or.null
   duplicate$ empty$ 'skip$
     {
-      "volume" bibinfo.check
+      % "volume" bibinfo.check
     }
   if$
   number "number" bibinfo.check duplicate$ empty$ 'skip$
@@ -1219,7 +1219,17 @@ FUNCTION {inproceedings}
   new.sentence
   crossref missing$
     { format.in.ed.booktitle "booktitle" output.check
-      format.bvolume output
+      % 修改这里的 volume 和 number 输出格式
+      volume empty$
+        'skip$
+        { ", " * 
+          volume * 
+          number empty$
+            'skip$
+            { "(" * number * ")" * }
+          if$
+        }
+      if$
       format.number.series output
       publisher empty$
         { format.organization.address output }


### PR DESCRIPTION
### **原来的版本：**
***输入：***
```
@inproceedings{zhang2017deep,
	title={Deep spatio-temporal residual networks for citywide crowd flows prediction},
	author={Zhang, Junbo and Zheng, Yu and Qi, Dekang},
	booktitle={Proceedings of the AAAI conference on artificial intelligence},
	volume={31},
	number={1},
	year={2017}
}
```
***输出：***
Zhang J, Zheng Y, Qi D. Deep spatio-temporal residual networks for citywide crowd flows
prediction [C]. Proceedings of the AAAI conference on artificial intelligence, **volume 31**, 2017.
### **修改后的版本输出：**
Zhang J, Zheng Y, Qi D. Deep spatio-temporal residual networks for citywide crowd flows
prediction [C]. Proceedings of the AAAI conference on artificial intelligence, **31(1)**, 2017.